### PR TITLE
fix building EMT.php on newer PHP versions

### DIFF
--- a/builder/builder.php
+++ b/builder/builder.php
@@ -39,7 +39,7 @@ HTML;
 			return implode("\n", $a);
 		}
 		
-		function phpfile_read($file, &$size, $all = false)
+		function phpfile_read($file, $all = false)
 		{
 			$size = filesize($file);
 			$fp2 = fopen($file, "r");
@@ -61,8 +61,7 @@ HTML;
 				$s = removebetween($s, "/**PYTHON", "PYTHON**/");
 				$s = removelinewith($s, "replacement_py");
 			}
-			
-			$size = strlen($s);
+
 			return $s;
 		}
 		
@@ -99,8 +98,8 @@ CODE
 	
 		foreach($list as $file )
 		{
-			$s = phpfile_read("../src-php/$file", $size, $action == "installerpy");
-			fputs($fp, $s, $size );
+			$s = phpfile_read("../src-php/$file", $action == "installerpy");
+			fputs($fp, $s);
 		}
 		
 		fprintf($fp, "?>");


### PR DESCRIPTION
EMT.php не собирался на php 5.6 т.к. в конечный файл записывалась лишь часть исходного, из-за того что strlen возвращает не количество байтов а количество символов в строке.

Патч совместим и с новыми и со старыми версиями PHP.