### PR TITLE
Replacement word-spacing to white-space

### DIFF
--- a/src-php/EMT.Tret.Abbr.php
+++ b/src-php/EMT.Tret.Abbr.php
@@ -11,7 +11,7 @@ class EMT_Tret_Abbr extends EMT_Tret
 	public $domain_zones = array('ru','ру','com','ком','org','орг', 'уа', 'ua');
 	
 	public $classes = array(
-			'nowrap'           => 'word-spacing:nowrap;',
+			'nowrap'           => 'white-space:nowrap;',
 			);
 	
 	public $rules = array(

--- a/src-php/EMT.Tret.Date.php
+++ b/src-php/EMT.Tret.Date.php
@@ -9,7 +9,7 @@ class EMT_Tret_Date extends EMT_Tret
 	public $title = "Даты и дни";
 	
 	public $classes = array(
-			'nowrap'           => 'word-spacing:nowrap;',
+			'nowrap'           => 'white-space:nowrap;',
 			);
 	
 	public $rules = array(

--- a/src-php/EMT.Tret.Etc.php
+++ b/src-php/EMT.Tret.Etc.php
@@ -9,7 +9,7 @@ class EMT_Tret_Etc extends EMT_Tret
 	
 	
 	public $classes = array(
-			'nowrap'           => 'word-spacing:nowrap;',
+			'nowrap'           => 'white-space:nowrap;',
 		);
 	
 	

--- a/src-php/EMT.Tret.Nobr.php
+++ b/src-php/EMT.Tret.Nobr.php
@@ -9,7 +9,7 @@ class EMT_Tret_Nobr extends EMT_Tret
 	public $title = "Неразрывные конструкции";
 	
 	public $classes = array(
-			'nowrap'           => 'word-spacing:nowrap;',
+			'nowrap'           => 'white-space:nowrap;',
 			);
 	
 	public $rules = array(

--- a/src-php/EMT.Tret.Space.php
+++ b/src-php/EMT.Tret.Space.php
@@ -12,7 +12,7 @@ class EMT_Tret_Space extends EMT_Tret
 	                             'com', 'net', 'edu', 'gov', 'org', 'mil', 'int', 'info', 'biz', 'info', 'name', 'pro');
 	
 	public $classes = array(
-			'nowrap'           => 'word-spacing:nowrap;',
+			'nowrap'           => 'white-space:nowrap;',
 			);
 	
 	public $rules = array(

--- a/src-php/EMT.Tret.Symbol.php
+++ b/src-php/EMT.Tret.Symbol.php
@@ -12,7 +12,7 @@ class EMT_Tret_Symbol extends EMT_Tret
 	 * @var array
 	 */
 	public $classes = array(
-			'nowrap'           => 'word-spacing:nowrap;',
+			'nowrap'           => 'white-space:nowrap;',
 		);
 	
 	

--- a/src-php/EMT.Tret.Text.php
+++ b/src-php/EMT.Tret.Text.php
@@ -7,7 +7,7 @@ require_once('EMT.Tret.php');
 class EMT_Tret_Text extends EMT_Tret
 {
 	public $classes = array(
-			'nowrap'           => 'word-spacing:nowrap;',
+			'nowrap'           => 'white-space:nowrap;',
 		);
 	
 	/**


### PR DESCRIPTION
Замена свойства word-spacing на правильный - white-space, которое используется в словах, в который требуется убрать перенос